### PR TITLE
enable c10s signing

### DIFF
--- a/templates/fedora-messaging/robosignatory.toml.j2
+++ b/templates/fedora-messaging/robosignatory.toml.j2
@@ -100,6 +100,13 @@ handlers = ["console"]
             # Stream tags
 
             [[consumer_config.koji_instances.primary.tags]]
+            from = "c10s-pending"
+            to = "c10s-pending-signed"
+            key = "{{ robosignatory_signing_key }}"
+            keyid = "{{ robosignatory_signing_keyid }}"
+            skip_untagging = true
+
+            [[consumer_config.koji_instances.primary.tags]]
             from = "c9s-pending"
             to = "c9s-pending-signed"
             key = "{{ robosignatory_signing_key }}"


### PR DESCRIPTION
Adding signign for c10s packages the same way it works for c8s and c9s.

https://issues.redhat.com/browse/CS-2141